### PR TITLE
(ImageProcessing) Adds intensity_histogram

### DIFF
--- a/ImageProcessing/src/image/image_processing/intensity_histogram.cal
+++ b/ImageProcessing/src/image/image_processing/intensity_histogram.cal
@@ -1,3 +1,5 @@
+
+
 /*
  * Copyright (c) 2017, Heriot-Watt University, Edinburgh
  * All rights reserved.
@@ -32,65 +34,63 @@
  * Date: 08.02.2017
  * See intensity_histogram.md for documentation.
  */
-
 package image.image_processing;
-import image.constants.constants.*;
 
-actor intensity_histogram() uint(size=8) Gin1 ==> uint(size=8) Gout :
+import image.constants.constants.* ;
+
+actor intensity_histogram () uint(size=8) Gin1 ==> uint(size=16) Gout :
+
 	uint(size=32) imagesize = IM_WIDTH_OUT * IM_HEIGHT_OUT * COLOUR_CHANNELS_OUT;
-    uint(size=32) p_count := 0;
-	uint(size=8) histogram [255] := [0]; 
-	uint(size=8) o_count := 0;
-	uint(size=8) i := 0;
-	
-	initActor: action ==> do
-	o_count := 0;
-	p_count := 0;
-	i := 0;
+
+	uint(size=32) p_count := 0;
+
+	uint(size=16) histogram [ 256 ] := [ 0 ];
+
+	uint(size=9) o_count := 0;
+
+	uint(size=9) i := 0;
+
+	initActor: action ==>
+	do
+		o_count := 0;
+		p_count := 0;
+		i := 0;
 	end
-	
-	initArray: action ==> do
-	histogram[i] := 0;
-	println("init "+i);
-	i := i+1;
-	
+
+	initArray: action ==>
+	guard
+	    i < 256
+	do
+		histogram[i] := 0;
+		i := i + 1;
 	end
-	
-	initDone: action ==>
-    guard i < 255
-    end
-    
-    processPixels: action Gin1:[x] ==> 
-    guard
-    	i = 255
-    do
-    histogram[x] := histogram[x] + 1;
-    p_count := p_count + 1;
-    end
-    
-    outputArray: action ==> Gout:[histogram[o_count]] 
-    guard
-    	p_count = imagesize,
-    	i = 255,
-    	o_count < 255
-    do
-    println("hist "+o_count+" - "+histogram[o_count]);
-    o_count := o_count + 1;
-   
-    end
-    
-    resetActor: action ==> 
-    guard
-    	o_count = 255
-    end
-	
-	schedule fsm init:
-		init (initActor) --> initHist;
-		initHist (initArray) --> read;
-		read (initDone) --> initHist;
-		read (processPixels) --> read;
-        read (outputArray) --> read;
-        read (resetActor) --> init;
-    end
+
+	processPixels: action Gin1:[ x ] ==>
+	guard
+		i = 256
+	do
+		histogram[x] := histogram[x] + 1;
+		p_count := p_count + 1;
+	end
+
+	outputArray: action ==> Gout:[ histogram[o_count-1] ]
+	guard
+		p_count = imagesize , i = 256 , o_count < 256
+	do
+		o_count := o_count + 1;
+	end
+
+	resetActor: action ==>
+	guard
+		o_count = 256
+	end
+
+	schedule fsm init :
+		init ( initActor ) --> read;
+		read ( initArray ) --> read;
+		read ( processPixels ) --> read;
+		read ( outputArray ) --> read;
+		read ( resetActor ) --> init;
+		end
 
 end

--- a/ImageProcessing/src/image/image_processing/intensity_histogram.cal
+++ b/ImageProcessing/src/image/image_processing/intensity_histogram.cal
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2017, Heriot-Watt University, Edinburgh
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   * Neither the name of the IRISA nor the names of its
+ *     contributors may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Author: Calum Turner <cajturner@gmail.com>
+ * Date: 08.02.2017
+ * See intensity_histogram.md for documentation.
+ */
+
+package image.image_processing;
+import image.constants.constants.*;
+
+actor intensity_histogram() uint(size=8) Gin1 ==> uint(size=8) Gout :
+	uint(size=32) imagesize = IM_WIDTH_OUT * IM_HEIGHT_OUT * COLOUR_CHANNELS_OUT;
+    uint(size=32) p_count := 0;
+	uint(size=8) histogram [255] := [0]; 
+	uint(size=8) o_count := 0;
+	uint(size=8) i := 0;
+	
+	initActor: action ==> do
+	o_count := 0;
+	p_count := 0;
+	i := 0;
+	end
+	
+	initArray: action ==> do
+	histogram[i] := 0;
+	println("init "+i);
+	i := i+1;
+	
+	end
+	
+	initDone: action ==>
+    guard i < 255
+    end
+    
+    processPixels: action Gin1:[x] ==> 
+    guard
+    	i = 255
+    do
+    histogram[x] := histogram[x] + 1;
+    p_count := p_count + 1;
+    end
+    
+    outputArray: action ==> Gout:[histogram[o_count]] 
+    guard
+    	p_count = imagesize,
+    	i = 255,
+    	o_count < 255
+    do
+    println("hist "+o_count+" - "+histogram[o_count]);
+    o_count := o_count + 1;
+   
+    end
+    
+    resetActor: action ==> 
+    guard
+    	o_count = 255
+    end
+	
+	schedule fsm init:
+		init (initActor) --> initHist;
+		initHist (initArray) --> read;
+		read (initDone) --> initHist;
+		read (processPixels) --> read;
+        read (outputArray) --> read;
+        read (resetActor) --> init;
+    end
+
+end

--- a/ImageProcessing/src/image/image_processing/intensity_histogram.md
+++ b/ImageProcessing/src/image/image_processing/intensity_histogram.md
@@ -1,0 +1,14 @@
+# intensity_histogram Actor #
+Creates a histogram of pixel value frequency
+
+## Inputs ##
+* **uint(size=8) Gin**: The stream to read image values from.
+
+## Outputs ##
+* **uint(size=8) Gout**: The histogram values from 0 - 255 in order
+
+## Usage ##
+
+Consumes each pixel then outputs the histogram in value order
+
+## Notes ##


### PR DESCRIPTION
This MR adds the intensity histogram actor. The actor expects a stream of pixels with values between 0-255. An array of occurrences for each value is created and once the whole image has been consumed, the array is streamed out of the actor from 0-255. The image size is calculated from the constants.

@RossBrunton @Teymoor-Ali @VincentDawn Could someone please review?

FYI @robstewart57 @KirstyRD